### PR TITLE
Identify root-frame of give sub-frame from the list of frames open in VS

### DIFF
--- a/CloseTabsToRight2022/Commands/CloseTabsToLeftCommand.cs
+++ b/CloseTabsToRight2022/Commands/CloseTabsToLeftCommand.cs
@@ -89,7 +89,7 @@ namespace CloseTabsToRight.Commands
             var windowFrames = vsWindowFrames.Select(vsWindowFrame => vsWindowFrame as WindowFrame);
             var activeFrame = GetActiveWindowFrame(vsWindowFrames, _dte);
 
-            var windowFrame = activeFrame;
+            var windowFrame = GetRootFrameIfSubFrame(activeFrame, windowFrames);
             if (windowFrame == null)
                 return;
 

--- a/CloseTabsToRight2022/Commands/CloseTabsToRightCommand.cs
+++ b/CloseTabsToRight2022/Commands/CloseTabsToRightCommand.cs
@@ -99,7 +99,7 @@ namespace CloseTabsToRight.Commands
             var windowFrames = vsWindowFrames.Select(vsWindowFrame => vsWindowFrame as WindowFrame);
             var activeFrame = GetActiveWindowFrame(vsWindowFrames, _dte);
 
-            var windowFrame = activeFrame;
+            var windowFrame = GetRootFrameIfSubFrame(activeFrame, windowFrames);
             if (windowFrame == null)
                 return;
 

--- a/CloseTabsToRight2022/Helpers/WindowFrameHelpers.cs
+++ b/CloseTabsToRight2022/Helpers/WindowFrameHelpers.cs
@@ -62,5 +62,22 @@ namespace CloseTabsToRight.Helpers
 
             return windowFrames;
         }
+
+        /// <summary>
+        /// Some tabs, eg. a xaml tab, will have multiple window frames associated to it, with one of them being the root of other "sub-frames" in the heirarchy. 
+        /// Sub-frames will have a null FrameView, so we need to return root as an active frame if the given active frame is a "sub-frame".
+        /// </summary>
+        /// <param name="allWindowFrames">Flat list of all window frames open in document group</param>
+        /// <param name="activeFrame">Active frame that might be a "sub-frame"</param>
+        /// <remarks>We need FrameView of a frame to be able to access DocumentGroup ancestor in heirarchy</remarks>
+        public static WindowFrame GetRootFrameIfSubFrame(WindowFrame activeFrame, IEnumerable<WindowFrame> allWindowFrames)
+        {
+            if (activeFrame.FrameView == null && allWindowFrames.Contains(activeFrame.RootFrame))
+            {
+                return activeFrame.RootFrame;
+            }
+
+            return activeFrame;
+        }
     }
 }


### PR DESCRIPTION
The patch fixes https://github.com/billpratt/CloseTabsToRight/issues/9, a bug in the original repo, which seems to be abandoned and also doesn't support VS2022. Hence, a pull request here.

**The bug**
With a Xaml tab opened in a "split-screen" mode (xaml preview and xaml markup), we have three different WindowFrame objects associated with the same tab.  The `GetActiveWindowFrame()` gives us the the wrong `WindowFrame` of the three.

**The fix**
The three `WindowFrame` objects seem to form a hierarchy of `WindowFrame`s among themselves (two of them having `RootFrame` property referencing the third "root" one). Only the root contains a non null `WindowFrame.FrameView` property needed to find Xaml Tab's ancestor in UI hierarchy (see `GetDocumentGroup()`). 

Since `GetActiveWindowFrame()` gives us a leaf frame of the Xaml-tab-associated `WindowFrame`s, we fix that by checking if `WindowFrame.FrameView` is null, and in that case assume it's a "sub-frame" to a root frame, and if the root frame is found in the given "flat-list" of window frames, we consider the root frame as the active one.  

@evan-kinney Let me know if you have any questions or feedback, I'd be happy to get back to you.